### PR TITLE
Added ability for components to have different edit form fields

### DIFF
--- a/src/components/EditForm.js
+++ b/src/components/EditForm.js
@@ -1,0 +1,44 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import TextField from '../components/TextField.js';
+
+export default class EditForm extends React.Component {
+  constructor(props) {
+    super(props);
+
+    // Bind functions
+    this.completeEditing = this.completeEditing.bind(this);
+    this.changeFieldLabel = this.changeFieldLabel.bind(this);
+  }
+
+  completeEditing(e) {
+    this.props.setEditing(false);
+  }
+
+  changeFieldLabel(value) {
+    this.props.changeFieldLabel(value);
+  }
+
+  render() {
+    return (
+      <div>
+        <h3 className="sidebar__heading">Edit {this.props.field.label}</h3>
+        <TextField
+          label="Label"
+          id="field-label"
+          value={this.props.field.label}
+          handleChange={this.changeFieldLabel}
+        />
+        <button className="btn btn-success" onClick={this.completeEditing}>
+          Done
+        </button>
+      </div>
+    );
+  }
+}
+
+EditForm.propTypes = {
+  field: PropTypes.object.isRequired,
+  setEditing: PropTypes.func.isRequired,
+  changeFieldLabeel: PropTypes.func.isRequired,
+};

--- a/src/containers/FieldList.js
+++ b/src/containers/FieldList.js
@@ -2,7 +2,7 @@ import React, { Component } from 'react';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 import { setEditing, reorderField, removeField } from '../actions/actions.js';
-import {SortableContainer, SortableElement, arrayMove} from 'react-sortable-hoc';
+import {SortableContainer, SortableElement} from 'react-sortable-hoc';
 
 class SortableFieldList extends Component {
   constructor() {

--- a/src/containers/FormBuilder.js
+++ b/src/containers/FormBuilder.js
@@ -3,11 +3,8 @@ import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 import { changeSelectedField, addField, setEditing, changeFieldLabel, removeField } from '../actions/actions.js';
 import Dropdown from '../components/Dropdown.js';
-import TextField from '../components/TextField.js';
-import RadioField from '../components/RadioField.js';
-import CheckboxField from '../components/CheckboxField.js';
+import EditForm from '../components/EditForm.js';
 import FieldList from './FieldList.js';
-import wrapField from '../components/FieldWrapper.js';
 
 class FormBuilder extends Component {
   constructor() {
@@ -15,7 +12,6 @@ class FormBuilder extends Component {
 
     this.handleChangeSelectField = this.handleChangeSelectField.bind(this);
     this.handleAddField = this.handleAddField.bind(this);
-    this.completeEditing = this.completeEditing.bind(this);
   }
 
   handleChangeSelectField(value) {
@@ -28,15 +24,28 @@ class FormBuilder extends Component {
     this.props.addField();
   }
 
-  completeEditing(e) {
+  handleSubmit(e) {
     e.preventDefault();
-
-    this.props.setEditing(false);
   }
+  
 
   render() {
+    let editForm;
+    if (this.props.editing !== false) {
+      const editingField = this.props.fields[this.props.editing];
+      const EditFormComponent = editingField.editForm !== undefined
+        ? editingField.editForm
+        : EditForm;
+
+      editForm = (
+        <div className="sidebar col-4 offset-1">
+          <EditFormComponent field={editingField} key={this.props.editing} setEditing={this.props.setEditing} changeFieldLabel={this.props.changeFieldLabel} />
+        </div>
+      );
+    }
+
     return (
-      <form className="form-builder row">
+      <form className="form-builder row" onSubmit={this.handleSubmit}>
         <div className={this.props.editing === false ? 'col-12' : 'col-7'}>
           <div className="form-builder__addform">
             <Dropdown
@@ -51,20 +60,7 @@ class FormBuilder extends Component {
           <FieldList fields={this.props.fields} />
         </div>
 
-        {this.props.editing !== false &&
-          <div className="sidebar col-4 offset-1">
-            <h3 className="sidebar__heading">Edit {this.props.fields[this.props.editing].label}</h3>
-            <TextField
-              label="Label"
-              id="field-label"
-              value={this.props.fields[this.props.editing].label}
-              handleChange={this.props.changeFieldLabel}
-            />
-            <button className="btn btn-success" onClick={this.completeEditing}>
-              Done
-            </button>
-          </div>
-        }
+        {editForm}
       </form>
     );
   }

--- a/src/reducers/reducer.js
+++ b/src/reducers/reducer.js
@@ -1,8 +1,8 @@
-import React from 'react';
 import Dropdown from '../components/Dropdown.js';
 import TextField from '../components/TextField.js';
 import RadioField from '../components/RadioField.js';
 import CheckboxField from '../components/CheckboxField.js';
+import EditForm from '../components/EditForm.js';
 import wrapField from '../components/FieldWrapper.js';
 import { arrayMove } from 'react-sortable-hoc';
 
@@ -13,7 +13,8 @@ const initialState = {
       value: 'text', 
       default: {
         label: 'Text field label',
-        component: wrapField(TextField) 
+        component: wrapField(TextField),
+        editForm: EditForm,
       }
     },
     { 
@@ -21,7 +22,8 @@ const initialState = {
       value: 'dropdown', 
       default: {
         label: 'Dropdown field label',
-        component: wrapField(Dropdown) 
+        component: wrapField(Dropdown),
+        editForm: EditForm,
       }
     },
     { 
@@ -29,7 +31,8 @@ const initialState = {
       value: 'radio', 
       default: {
         label: 'Radio group label',
-        component: wrapField(RadioField) 
+        component: wrapField(RadioField),
+        editForm: EditForm,
       }
     },
     { 
@@ -37,7 +40,8 @@ const initialState = {
       value: 'checkbox', 
       default: {
         label: 'Checkbox group label',
-        component: wrapField(CheckboxField)
+        component: wrapField(CheckboxField),
+        editForm: EditForm,
       }
     }
   ],
@@ -94,6 +98,7 @@ export default (state = initialState, action) => {
       }
 
       if (editing !== false && action.oldIndex === editing) {
+        editing = action.newIndex;
       }
 
       return {


### PR DESCRIPTION
Summary:
* Split out the edit form panel into its own component
* Added editForm prop to initial state
* render the edit form dynamically depending on component
* Added handleSubmit on the form so pressing 'Enter' doesn't add a new field


@scott1702 I've made this into a PR as I'm not sure if its the best way to do it in React.

This is the groundwork for adding options to the checkbox, dropdown and radio fields.